### PR TITLE
chore: bump `black` deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -242,7 +242,7 @@ varint==1.0.2
     # via multiaddr
 vvm==0.1.0
     # via -r requirements.in
-vyper==0.3.9
+vyper>=0.3.9
     # via -r requirements.in
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -242,7 +242,7 @@ varint==1.0.2
     # via multiaddr
 vvm==0.1.0
     # via -r requirements.in
-vyper>=0.3.9
+vyper>=0.3.7
     # via -r requirements.in
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ base58==2.1.1
     # via multiaddr
 bitarray>=2.6.0,<3
     # via eth-account
-black==22.10.0
+black==22.12.0
     # via -r requirements.in
 certifi==2022.9.24
     # via requests
@@ -30,9 +30,9 @@ charset-normalizer==2.1.1
     # via
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.7
     # via black
-cytoolz==0.12.0
+cytoolz==0.12.2
     # via
     #   eth-keyfile
     #   eth-utils
@@ -131,7 +131,7 @@ multidict==6.0.2
     # via
     #   aiohttp
     #   yarl
-mypy-extensions==0.4.3
+mypy-extensions==0.4.4
     # via black
 mythx-models==1.9.1
     # via pythx
@@ -143,7 +143,7 @@ parsimonious==0.8.1
     # via eth-abi
 pathspec==0.10.1
     # via black
-platformdirs==2.5.2
+platformdirs==4.1.0
     # via black
 pluggy==1.0.0
     # via pytest
@@ -236,8 +236,6 @@ toolz==0.12.0
     # via cytoolz
 tqdm==4.64.1
     # via -r requirements.in
-typing-extensions==4.4.0
-    # via black
 urllib3==1.26.12
     # via requests
 varint==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -242,7 +242,7 @@ varint==1.0.2
     # via multiaddr
 vvm==0.1.0
     # via -r requirements.in
-vyper==0.3.7
+vyper==0.3.9
     # via -r requirements.in
 wcwidth==0.2.5
     # via prompt-toolkit


### PR DESCRIPTION
this is needed for installing `safe-eth-py` in `multisig-ops/action-scripts/brownie`

see #746